### PR TITLE
Rue89: LMS Changes backport

### DIFF
--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -30,6 +30,8 @@ from openedx.core.lib.django_test_client_utils import get_absolute_url
 from openedx.core.djangoapps.user_api.models import UserOrgTag
 from student.tests.factories import UserFactory, CourseModeFactory
 from student.models import CourseEnrollment
+from student.roles import CourseStaffRole
+from student.tests.factories import AdminFactory, CourseModeFactory, UserFactory
 from embargo.test_utils import restrict_course
 
 
@@ -127,6 +129,9 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase):
     EMAIL = "bob@example.com"
     PASSWORD = "edx"
 
+    OTHER_USERNAME = "Jane"
+    OTHER_EMAIL = "jane@example.com"
+
     def setUp(self):
         """ Create a course and user, then log in. """
         super(EnrollmentTest, self).setUp()
@@ -139,8 +144,20 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase):
         self.rate_limit, rate_duration = throttle.parse_rate(throttle.rate)
 
         self.course = CourseFactory.create()
-        self.user = UserFactory.create(username=self.USERNAME, email=self.EMAIL, password=self.PASSWORD)
-        self.other_user = UserFactory.create()
+        # Load a CourseOverview. This initial load should result in a cache
+        # miss; the modulestore is queried and course metadata is cached.
+        __ = CourseOverview.get_from_id(self.course.id)
+
+        self.user = UserFactory.create(
+            username=self.USERNAME,
+            email=self.EMAIL,
+            password=self.PASSWORD,
+        )
+        self.other_user = UserFactory.create(
+            username=self.OTHER_USERNAME,
+            email=self.OTHER_EMAIL,
+            password=self.PASSWORD,
+        )
         self.client.login(username=self.USERNAME, password=self.PASSWORD)
 
     @ddt.data(
@@ -290,20 +307,57 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase):
         self.client.logout()
         self.assert_enrollment_status(username=self.other_user.username, as_server=True)
 
-    def test_user_does_not_match_param_for_list(self):
-        CourseModeFactory.create(
-            course_id=self.course.id,
-            mode_slug=CourseMode.HONOR,
-            mode_display_name=CourseMode.HONOR,
+    def _assert_enrollments_visible_in_list(self, courses, use_server_key=False):
+        """
+        Check that the list of enrollments of self.user returned for the currently logged in user
+        matches the list of courses passed in in 'courses'.
+        """
+        kwargs = {}
+        if use_server_key:
+            kwargs.update(HTTP_X_EDX_API_KEY=self.API_KEY)
+        response = self.client.get(reverse('courseenrollments'), {'user': self.user.username}, **kwargs)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = json.loads(response.content)
+        self.assertItemsEqual(
+            [enrollment['course_details']['course_id'] for enrollment in data],
+            [unicode(course.id) for course in courses]
         )
-        resp = self.client.get(reverse('courseenrollments'), {'user': self.other_user.username})
-        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
-        # Verify that the server still has access to this endpoint.
+
+    def test_enrollment_list_permissions(self):
+        """
+        Test that the correct list of enrollments is returned, depending on the permissions of the
+        requesting user.
+        """
+        # Create another course, and enroll self.user in both courses.
+        other_course = CourseFactory.create()
+        for course in self.course, other_course:
+            CourseModeFactory.create(
+                course_id=unicode(course.id),
+                mode_slug=CourseMode.HONOR,
+                mode_display_name=CourseMode.HONOR,
+            )
+            self.assert_enrollment_status(
+                course_id=unicode(course.id),
+                max_mongo_calls=1,
+            )
+        # Verify the user himself can see both of his enrollments.
+        self._assert_enrollments_visible_in_list([self.course, other_course])
+        # Verify that self.other_user can't see any of the enrollments.
+        self.client.login(username=self.OTHER_USERNAME, password=self.PASSWORD)
+        self._assert_enrollments_visible_in_list([])
+        # Create a staff user for self.course (but nor for other_course) and log her in.
+        staff_user = UserFactory.create(username='staff', email='staff@example.com', password=self.PASSWORD)
+        CourseStaffRole(self.course.id).add_users(staff_user)
+        self.client.login(username='staff', password=self.PASSWORD)
+        # Verify that she can see only the enrollment in the course she has staff privileges for.
+        self._assert_enrollments_visible_in_list([self.course])
+        # Create a global staff user, and verify she can see all enrollments.
+        AdminFactory(username='global_staff', email='global_staff@example.com', password=self.PASSWORD)
+        self.client.login(username='global_staff', password=self.PASSWORD)
+        self._assert_enrollments_visible_in_list([self.course, other_course])
+        # Verify the server can see all enrollments.
         self.client.logout()
-        resp = self.client.get(
-            reverse('courseenrollments'), {'username': self.other_user.username}, **{'HTTP_X_EDX_API_KEY': self.API_KEY}
-        )
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self._assert_enrollments_visible_in_list([self.course, other_course], use_server_key=True)
 
     def test_user_does_not_match_param(self):
         """

--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -144,9 +144,6 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase):
         self.rate_limit, rate_duration = throttle.parse_rate(throttle.rate)
 
         self.course = CourseFactory.create()
-        # Load a CourseOverview. This initial load should result in a cache
-        # miss; the modulestore is queried and course metadata is cached.
-        __ = CourseOverview.get_from_id(self.course.id)
 
         self.user = UserFactory.create(
             username=self.USERNAME,
@@ -336,10 +333,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase):
                 mode_slug=CourseMode.HONOR,
                 mode_display_name=CourseMode.HONOR,
             )
-            self.assert_enrollment_status(
-                course_id=unicode(course.id),
-                max_mongo_calls=1,
-            )
+            self.assert_enrollment_status(course_id=unicode(course.id))
         # Verify the user himself can see both of his enrollments.
         self._assert_enrollments_visible_in_list([self.course, other_course])
         # Verify that self.other_user can't see any of the enrollments.

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -31,7 +31,9 @@ from enrollment.errors import (
     CourseNotFoundError, CourseEnrollmentError,
     CourseModeNotFoundError, CourseEnrollmentExistsError
 )
+from student.auth import user_has_role
 from student.models import User
+from student.roles import CourseStaffRole, GlobalStaff
 
 log = logging.getLogger(__name__)
 
@@ -345,14 +347,15 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
     # cross-domain CSRF.
     @method_decorator(ensure_csrf_cookie_cross_domain)
     def get(self, request):
-        """Gets a list of all course enrollments for the currently logged in user."""
+        """Gets a list of all course enrollments for a user.
+
+        Returns a list for the currently logged in user, or for the user named by the 'user' GET
+        parameter.  If the username does not match the currently logged in user, only courses the
+        requesting user has staff permissions for are listed.
+        """
         username = request.GET.get('user', request.user.username)
-        if request.user.username != username and not self.has_api_key_permissions(request):
-            # Return a 404 instead of a 403 (Unauthorized). If one user is looking up
-            # other users, do not let them deduce the existence of an enrollment.
-            return Response(status=status.HTTP_404_NOT_FOUND)
         try:
-            return Response(api.get_enrollments(username))
+            enrollment_data = api.get_enrollments(username)
         except CourseEnrollmentError:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
@@ -362,6 +365,15 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                     ).format(username=username)
                 }
             )
+        if username == request.user.username or GlobalStaff().has_user(request.user) or \
+                self.has_api_key_permissions(request):
+            return Response(enrollment_data)
+        filtered_data = []
+        for enrollment in enrollment_data:
+            course_key = CourseKey.from_string(enrollment["course_details"]["course_id"])
+            if user_has_role(request.user, CourseStaffRole(course_key)):
+                filtered_data.append(enrollment)
+        return Response(filtered_data)
 
     def post(self, request):
         """Enrolls the currently logged-in user in a course.

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -31,7 +31,7 @@ from enrollment.errors import (
     CourseNotFoundError, CourseEnrollmentError,
     CourseModeNotFoundError, CourseEnrollmentExistsError
 )
-from student.auth import user_has_role
+from student.auth import has_access
 from student.models import User
 from student.roles import CourseStaffRole, GlobalStaff
 
@@ -371,7 +371,7 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
         filtered_data = []
         for enrollment in enrollment_data:
             course_key = CourseKey.from_string(enrollment["course_details"]["course_id"])
-            if user_has_role(request.user, CourseStaffRole(course_key)):
+            if has_access(request.user, CourseStaffRole(course_key)):
                 filtered_data.append(enrollment)
         return Response(filtered_data)
 

--- a/lms/djangoapps/discussion_api/api.py
+++ b/lms/djangoapps/discussion_api/api.py
@@ -24,13 +24,7 @@ from discussion_api.permissions import (
     get_initializable_thread_fields,
 )
 from discussion_api.serializers import CommentSerializer, ThreadSerializer, get_context
-from django_comment_client.base.views import (
-    THREAD_CREATED_EVENT_NAME,
-    get_comment_created_event_data,
-    get_comment_created_event_name,
-    get_thread_created_event_data,
-    track_forum_event,
-)
+from django_comment_client.base.views import track_comment_created_event, track_thread_created_event
 from django_comment_client.utils import get_accessible_discussion_modules
 from lms.lib.comment_client.comment import Comment
 from lms.lib.comment_client.thread import Thread
@@ -507,13 +501,7 @@ def create_thread(request, thread_data):
     api_thread = serializer.data
     _do_extra_actions(api_thread, cc_thread, thread_data.keys(), actions_form, context)
 
-    track_forum_event(
-        request,
-        THREAD_CREATED_EVENT_NAME,
-        course,
-        cc_thread,
-        get_thread_created_event_data(cc_thread, followed=actions_form.cleaned_data["following"])
-    )
+    track_thread_created_event(request, course, cc_thread, actions_form.cleaned_data["following"])
 
     return api_thread
 
@@ -553,13 +541,7 @@ def create_comment(request, comment_data):
     api_comment = serializer.data
     _do_extra_actions(api_comment, cc_comment, comment_data.keys(), actions_form, context)
 
-    track_forum_event(
-        request,
-        get_comment_created_event_name(cc_comment),
-        context["course"],
-        cc_comment,
-        get_comment_created_event_data(cc_comment, cc_thread["commentable_id"], followed=False)
-    )
+    track_comment_created_event(request, context["course"], cc_comment, cc_thread["commentable_id"], followed=False)
 
     return api_comment
 

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -1,3 +1,4 @@
+import ddt
 import logging
 import json
 

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -93,7 +93,8 @@ class ThreadActionGroupIdTestCase(
                 "user_id": str(self.student.id),
                 "group_id": self.student_cohort.id,
                 "closed": False,
-                "type": "thread"
+                "type": "thread",
+                "commentable_id": "commentable_id",
             }
         )
         mock_request.return_value.status_code = 200
@@ -993,7 +994,6 @@ class CreateSubCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, Moc
 
 
 @ddt.ddt
-@disable_signal(views, 'comment_created')
 class ForumEventTestCase(ModuleStoreTestCase, MockRequestSetupMixin):
     """
     Forum actions are expected to launch analytics events. Test these here.

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -991,6 +991,8 @@ class CreateSubCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, Moc
             del Thread.commentable_id
 
 
+@ddt.ddt
+@disable_signal(views, 'comment_created')
 class ForumEventTestCase(ModuleStoreTestCase, MockRequestSetupMixin):
     """
     Forum actions are expected to launch analytics events. Test these here.
@@ -1087,6 +1089,40 @@ class ForumEventTestCase(ModuleStoreTestCase, MockRequestSetupMixin):
         self.assertEqual(event['user_forums_roles'], ['Student'])
         self.assertEqual(event['user_course_roles'], ['Wizard'])
         self.assertEqual(event['options']['followed'], False)
+
+    @ddt.data(
+        ('vote_for_thread', 'thread_id', 'thread'),
+        ('undo_vote_for_thread', 'thread_id', 'thread'),
+        ('vote_for_comment', 'comment_id', 'response'),
+        ('undo_vote_for_comment', 'comment_id', 'response'),
+    )
+    @ddt.unpack
+    @patch('eventtracking.tracker.emit')
+    @patch('lms.lib.comment_client.utils.requests.request')
+    def test_thread_voted_event(self, view_name, obj_id_name, obj_type, mock_request, mock_emit):
+        undo = view_name.startswith('undo')
+
+        self._set_mock_request_data(mock_request, {
+            'closed': False,
+            'commentable_id': 'test_commentable_id',
+            'username': 'gumprecht',
+        })
+        request = RequestFactory().post('dummy_url', {})
+        request.user = self.student
+        request.view_name = view_name
+        view_function = getattr(views, view_name)
+        kwargs = dict(course_id=unicode(self.course.id))
+        kwargs[obj_id_name] = obj_id_name
+        if not undo:
+            kwargs.update(value='up')
+        view_function(request, **kwargs)
+
+        self.assertTrue(mock_emit.called)
+        event_name, event = mock_emit.call_args[0]
+        self.assertEqual(event_name, 'edx.forum.{}.voted'.format(obj_type))
+        self.assertEqual(event['target_username'], 'gumprecht')
+        self.assertEqual(event['undo_vote'], undo)
+        self.assertEqual(event['vote_value'], 'up')
 
 
 class UsersEndpointTestCase(ModuleStoreTestCase, MockRequestSetupMixin):

--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -38,9 +38,100 @@ log = logging.getLogger(__name__)
 
 TRACKING_MAX_FORUM_BODY = 2000
 
-THREAD_CREATED_EVENT_NAME = "edx.forum.thread.created"
-RESPONSE_CREATED_EVENT_NAME = 'edx.forum.response.created'
-COMMENT_CREATED_EVENT_NAME = 'edx.forum.comment.created'
+_EVENT_NAME_TEMPLATE = 'edx.forum.{obj_type}.{action_name}'
+
+
+def track_forum_event(request, event_name, course, obj, data, id_map=None):
+    """
+    Send out an analytics event when a forum event happens. Works for threads,
+    responses to threads, and comments on those responses.
+    """
+    user = request.user
+    data['id'] = obj.id
+    if id_map is None:
+        id_map = get_discussion_id_map(course, user)
+
+    commentable_id = data['commentable_id']
+    if commentable_id in id_map:
+        data['category_name'] = id_map[commentable_id]["title"]
+        data['category_id'] = commentable_id
+    data['url'] = request.META.get('HTTP_REFERER', '')
+    data['user_forums_roles'] = [
+        role.name for role in user.roles.filter(course_id=course.id)
+    ]
+    data['user_course_roles'] = [
+        role.role for role in user.courseaccessrole_set.filter(course_id=course.id)
+    ]
+
+    tracker.emit(event_name, data)
+
+
+def track_created_event(request, event_name, course, obj, data, id_map=None):
+    """
+    Send analytics event for a newly created thread, response or comment.
+    """
+    if len(obj.body) > TRACKING_MAX_FORUM_BODY:
+        data['truncated'] = True
+    else:
+        data['truncated'] = False
+    data['body'] = obj.body[:TRACKING_MAX_FORUM_BODY]
+    track_forum_event(request, event_name, course, obj, data, id_map=id_map)
+
+
+def track_thread_created_event(request, course, thread, followed, id_map=None):
+    """
+    Send analytics event for a newly created thread.
+    """
+    event_name = _EVENT_NAME_TEMPLATE.format(obj_type='thread', action_name='created')
+    event_data = {
+        'commentable_id': thread.commentable_id,
+        'group_id': thread.get("group_id"),
+        'thread_type': thread.thread_type,
+        'title': thread.title,
+        'anonymous': thread.anonymous,
+        'anonymous_to_peers': thread.anonymous_to_peers,
+        'options': {'followed': followed},
+        # There is a stated desire for an 'origin' property that will state
+        # whether this thread was created via courseware or the forum.
+        # However, the view does not contain that data, and including it will
+        # likely require changes elsewhere.
+    }
+    track_created_event(request, event_name, course, thread, event_data, id_map=id_map)
+
+
+def track_comment_created_event(request, course, comment, commentable_id, followed, id_map=None):
+    """
+    Send analytics event for a newly created response or comment.
+    """
+    obj_type = 'comment' if comment.get("parent_id") else 'response'
+    event_name = _EVENT_NAME_TEMPLATE.format(obj_type=obj_type, action_name='created')
+    event_data = {
+        'discussion': {'id': comment.thread_id},
+        'commentable_id': commentable_id,
+        'options': {'followed': followed},
+    }
+    parent_id = comment.get('parent_id')
+    if parent_id:
+        event_data['response'] = {'id': parent_id}
+    track_created_event(request, event_name, course, comment, event_data, id_map=id_map)
+
+
+def track_voted_event(request, course, obj, vote_value, undo_vote=False, id_map=None):
+    """
+    Send analytics event for a vote on a thread or response.
+    """
+    if isinstance(obj, cc.Thread):
+        obj_type = 'thread'
+    else:
+        obj_type = 'response'
+    event_name = _EVENT_NAME_TEMPLATE.format(obj_type=obj_type, action_name='voted')
+    event_data = {
+        'commentable_id': obj.commentable_id,
+        'target_username': obj.get('username'),
+        'undo_vote': undo_vote,
+        'vote_value': vote_value,
+    }
+    track_forum_event(request, event_name, course, obj, event_data, id_map=id_map)
 
 
 def permitted(fn):
@@ -51,6 +142,8 @@ def permitted(fn):
                 content = cc.Thread.find(kwargs["thread_id"]).to_dict()
             elif "comment_id" in kwargs:
                 content = cc.Comment.find(kwargs["comment_id"]).to_dict()
+            elif "commentable_id" in kwargs:
+                content = cc.Commentable.find(kwargs["commentable_id"]).to_dict()
             else:
                 content = None
             return content
@@ -69,80 +162,6 @@ def ajax_content_response(request, course_key, content):
         'content': prepare_content(content, course_key),
         'annotated_content_info': annotated_content_info,
     })
-
-
-def track_forum_event(request, event_name, course, obj, data, id_map=None):
-    """
-    Send out an analytics event when a forum event happens. Works for threads,
-    responses to threads, and comments on those responses.
-    """
-    user = request.user
-    data['id'] = obj.id
-    if id_map is None:
-        id_map = get_discussion_id_map(course, user)
-
-    commentable_id = data['commentable_id']
-    if commentable_id in id_map:
-        data['category_name'] = id_map[commentable_id]["title"]
-        data['category_id'] = commentable_id
-    if len(obj.body) > TRACKING_MAX_FORUM_BODY:
-        data['truncated'] = True
-    else:
-        data['truncated'] = False
-
-    data['body'] = obj.body[:TRACKING_MAX_FORUM_BODY]
-    data['url'] = request.META.get('HTTP_REFERER', '')
-    data['user_forums_roles'] = [
-        role.name for role in user.roles.filter(course_id=course.id)
-    ]
-    data['user_course_roles'] = [
-        role.role for role in user.courseaccessrole_set.filter(course_id=course.id)
-    ]
-
-    tracker.emit(event_name, data)
-
-
-def get_thread_created_event_data(thread, followed):
-    """
-    Get the event data payload for thread creation (excluding fields populated
-    by track_forum_event)
-    """
-    return {
-        'commentable_id': thread.commentable_id,
-        'group_id': thread.get("group_id"),
-        'thread_type': thread.thread_type,
-        'title': thread.title,
-        'anonymous': thread.anonymous,
-        'anonymous_to_peers': thread.anonymous_to_peers,
-        'options': {'followed': followed},
-        # There is a stated desire for an 'origin' property that will state
-        # whether this thread was created via courseware or the forum.
-        # However, the view does not contain that data, and including it will
-        # likely require changes elsewhere.
-    }
-
-
-def get_comment_created_event_name(comment):
-    """Get the appropriate event name for creating a response/comment"""
-    return COMMENT_CREATED_EVENT_NAME if comment.get("parent_id") else RESPONSE_CREATED_EVENT_NAME
-
-
-def get_comment_created_event_data(comment, commentable_id, followed):
-    """
-    Get the event data payload for comment creation (excluding fields populated
-    by track_forum_event)
-    """
-    event_data = {
-        'discussion': {'id': comment.thread_id},
-        'commentable_id': commentable_id,
-        'options': {'followed': followed},
-    }
-
-    parent_id = comment.get("parent_id")
-    if parent_id:
-        event_data['response'] = {'id': parent_id}
-
-    return event_data
 
 
 @require_POST
@@ -204,7 +223,6 @@ def create_thread(request, course_id, commentable_id):
         user = cc.User.from_django_user(request.user)
         user.follow(thread)
 
-    event_data = get_thread_created_event_data(thread, follow)
     data = thread.to_dict()
 
     # Calls to id map are expensive, but we need this more than once.
@@ -213,8 +231,7 @@ def create_thread(request, course_id, commentable_id):
 
     add_courseware_context([data], course, request.user, id_map=id_map)
 
-    track_forum_event(request, THREAD_CREATED_EVENT_NAME,
-                      course, thread, event_data, id_map=id_map)
+    track_thread_created_event(request, course, thread, follow, id_map=id_map)
 
     if request.is_ajax():
         return ajax_content_response(request, course_key, data)
@@ -296,9 +313,7 @@ def _create_comment(request, course_key, thread_id=None, parent_id=None):
         user = cc.User.from_django_user(request.user)
         user.follow(comment.thread)
 
-    event_name = get_comment_created_event_name(comment)
-    event_data = get_comment_created_event_data(comment, comment.thread.commentable_id, followed)
-    track_forum_event(request, event_name, course, comment, event_data)
+    track_comment_created_event(request, course, comment, comment.thread.commentable_id, followed)
 
     if request.is_ajax():
         return ajax_content_response(request, course_key, comment.to_dict())
@@ -416,6 +431,22 @@ def delete_comment(request, course_id, comment_id):
     return JsonResponse(prepare_content(comment.to_dict(), course_key))
 
 
+def _vote_or_unvote(request, course_id, obj, value):
+    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+    course = get_course_with_access(request.user, 'load', course_key)
+    user = cc.User.from_django_user(request.user)
+    if value == 'undo':
+        user.unvote(obj)
+        # TODO(smarnach): Determine the value of the vote that is undone.  Currently, you can
+        # only cast upvotes in the user interface, so it is assumed that the vote value is 'up'.
+        # (People could theoretically downvote by handcrafting AJAX requests.)
+        track_voted_event(request, course, obj, 'up', undo_vote=True)
+    else:
+        user.vote(obj, value)
+        track_voted_event(request, course, obj, value)
+    return JsonResponse(prepare_content(obj.to_dict(), course_key))
+
+
 @require_POST
 @login_required
 @permitted
@@ -423,11 +454,10 @@ def vote_for_comment(request, course_id, comment_id, value):
     """
     given a course_id and comment_id,
     """
-    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
-    user = cc.User.from_django_user(request.user)
     comment = cc.Comment.find(comment_id)
-    user.vote(comment, value)
-    return JsonResponse(prepare_content(comment.to_dict(), course_key))
+    result = _vote_or_unvote(request, course_id, comment, value)
+    comment_voted.send(sender=None, user=request.user, post=comment)
+    return result
 
 
 @require_POST
@@ -438,11 +468,7 @@ def undo_vote_for_comment(request, course_id, comment_id):
     given a course id and comment id, remove vote
     ajax only
     """
-    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
-    user = cc.User.from_django_user(request.user)
-    comment = cc.Comment.find(comment_id)
-    user.unvote(comment)
-    return JsonResponse(prepare_content(comment.to_dict(), course_key))
+    return _vote_or_unvote(request, course_id, cc.Comment.find(comment_id), 'undo')
 
 
 @require_POST
@@ -453,12 +479,21 @@ def vote_for_thread(request, course_id, thread_id, value):
     given a course id and thread id vote for this thread
     ajax only
     """
-    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
-    user = cc.User.from_django_user(request.user)
     thread = cc.Thread.find(thread_id)
-    user.vote(thread, value)
+    result = _vote_or_unvote(request, course_id, thread, value)
+    thread_voted.send(sender=None, user=request.user, post=thread)
+    return result
 
-    return JsonResponse(prepare_content(thread.to_dict(), course_key))
+
+@require_POST
+@login_required
+@permitted
+def undo_vote_for_thread(request, course_id, thread_id):
+    """
+    given a course id and thread id, remove users vote for thread
+    ajax only
+    """
+    return _vote_or_unvote(request, course_id, cc.Thread.find(thread_id), 'undo')
 
 
 @require_POST
@@ -531,22 +566,6 @@ def un_flag_abuse_for_comment(request, course_id, comment_id):
     comment = cc.Comment.find(comment_id)
     comment.unFlagAbuse(user, comment, remove_all)
     return JsonResponse(prepare_content(comment.to_dict(), course_key))
-
-
-@require_POST
-@login_required
-@permitted
-def undo_vote_for_thread(request, course_id, thread_id):
-    """
-    given a course id and thread id, remove users vote for thread
-    ajax only
-    """
-    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
-    user = cc.User.from_django_user(request.user)
-    thread = cc.Thread.find(thread_id)
-    user.unvote(thread)
-
-    return JsonResponse(prepare_content(thread.to_dict(), course_key))
 
 
 @require_POST

--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -142,8 +142,6 @@ def permitted(func):
                 content = cc.Thread.find(kwargs["thread_id"]).to_dict()
             elif "comment_id" in kwargs:
                 content = cc.Comment.find(kwargs["comment_id"]).to_dict()
-            elif "commentable_id" in kwargs:
-                content = cc.Commentable.find(kwargs["commentable_id"]).to_dict()
             else:
                 content = None
             return content

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -4,6 +4,7 @@ Unit tests for instructor.api methods.
 """
 import datetime
 import ddt
+import functools
 import random
 import pytz
 import io
@@ -28,6 +29,7 @@ from mock import Mock, patch
 from nose.tools import raises
 from nose.plugins.attrib import attr
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.locator import UsageKey
 
 from course_modes.models import CourseMode
 from courseware.models import StudentModule
@@ -101,6 +103,12 @@ REPORTS_DATA = (
         'report_type': 'students who may enroll',
         'instructor_api_endpoint': 'get_students_who_may_enroll',
         'task_api_endpoint': 'instructor_task.api.submit_calculate_may_enroll_csv',
+        'extra_instructor_api_kwargs': {},
+    },
+    {
+        'report_type': 'problem responses',
+        'instructor_api_endpoint': 'get_problem_responses',
+        'task_api_endpoint': 'instructor_task.api.submit_calculate_problem_responses_csv',
         'extra_instructor_api_kwargs': {},
     }
 )
@@ -226,6 +234,7 @@ class TestInstructorAPIDenyLevels(ModuleStoreTestCase, LoginEnrollmentTestCase):
             ('get_enrollment_report', {}),
             ('get_students_who_may_enroll', {}),
             ('get_exec_summary_report', {}),
+            ('get_problem_responses', {}),
         ]
         # Endpoints that only Instructors can access
         self.instructor_level_endpoints = [
@@ -278,6 +287,20 @@ class TestInstructorAPIDenyLevels(ModuleStoreTestCase, LoginEnrollmentTestCase):
                 "Student should not be allowed to access endpoint " + endpoint
             )
 
+    def _access_problem_responses_endpoint(self, msg):
+        """
+        Access endpoint for problem responses report, ensuring that
+        UsageKey.from_string returns a problem key that the endpoint
+        can work with.
+
+        msg: message to display if assertion fails.
+        """
+        mock_problem_key = Mock(return_value=u'')
+        mock_problem_key.course_key = self.course.id
+        with patch.object(UsageKey, 'from_string') as patched_method:
+            patched_method.return_value = mock_problem_key
+            self._access_endpoint('get_problem_responses', {}, 200, msg)
+
     def test_staff_level(self):
         """
         Ensure that a staff member can't access instructor endpoints.
@@ -292,6 +315,11 @@ class TestInstructorAPIDenyLevels(ModuleStoreTestCase, LoginEnrollmentTestCase):
         for endpoint, args in self.staff_level_endpoints:
             # TODO: make these work
             if endpoint in ['update_forum_role_membership', 'proxy_legacy_analytics', 'list_forum_members']:
+                continue
+            elif endpoint == 'get_problem_responses':
+                self._access_problem_responses_endpoint(
+                    "Staff member should be allowed to access endpoint " + endpoint
+                )
                 continue
             self._access_endpoint(
                 endpoint,
@@ -321,6 +349,11 @@ class TestInstructorAPIDenyLevels(ModuleStoreTestCase, LoginEnrollmentTestCase):
         for endpoint, args in self.staff_level_endpoints:
             # TODO: make these work
             if endpoint in ['update_forum_role_membership', 'proxy_legacy_analytics']:
+                continue
+            elif endpoint == 'get_problem_responses':
+                self._access_problem_responses_endpoint(
+                    "Instructor should be allowed to access endpoint " + endpoint
+                )
                 continue
             self._access_endpoint(
                 endpoint,
@@ -2264,6 +2297,78 @@ class TestInstructorAPILevelsDataDump(ModuleStoreTestCase, LoginEnrollmentTestCa
         self.assertEqual(res['total_used_codes'], used_codes)
         self.assertEqual(res['total_codes'], 5)
 
+    def test_get_problem_responses_invalid_location(self):
+        """
+        Test whether get_problem_responses returns an appropriate status
+        message when users submit an invalid problem location.
+        """
+        url = reverse(
+            'get_problem_responses',
+            kwargs={'course_id': unicode(self.course.id)}
+        )
+        problem_location = ''
+
+        response = self.client.get(url, {'problem_location': problem_location})
+        res_json = json.loads(response.content)
+        self.assertEqual(res_json, 'Could not find problem with this location.')
+
+    def valid_problem_location(test):  # pylint: disable=no-self-argument
+        """
+        Decorator for tests that target get_problem_responses endpoint and
+        need to pretend user submitted a valid problem location.
+        """
+        @functools.wraps(test)
+        def wrapper(self, *args, **kwargs):
+            """
+            Run `test` method, ensuring that UsageKey.from_string returns a
+            problem key that the get_problem_responses endpoint can
+            work with.
+            """
+            mock_problem_key = Mock(return_value=u'')
+            mock_problem_key.course_key = self.course.id
+            with patch.object(UsageKey, 'from_string') as patched_method:
+                patched_method.return_value = mock_problem_key
+                test(self, *args, **kwargs)
+        return wrapper
+
+    @valid_problem_location
+    def test_get_problem_responses_successful(self):
+        """
+        Test whether get_problem_responses returns an appropriate status
+        message if CSV generation was started successfully.
+        """
+        url = reverse(
+            'get_problem_responses',
+            kwargs={'course_id': unicode(self.course.id)}
+        )
+        problem_location = ''
+
+        response = self.client.get(url, {'problem_location': problem_location})
+        res_json = json.loads(response.content)
+        self.assertIn('status', res_json)
+        status = res_json['status']
+        self.assertIn('is being generated', status)
+        self.assertNotIn('already in progress', status)
+
+    @valid_problem_location
+    def test_get_problem_responses_already_running(self):
+        """
+        Test whether get_problem_responses returns an appropriate status
+        message if CSV generation is already in progress.
+        """
+        url = reverse(
+            'get_problem_responses',
+            kwargs={'course_id': unicode(self.course.id)}
+        )
+
+        with patch('instructor_task.api.submit_calculate_problem_responses_csv') as submit_task_function:
+            error = AlreadyRunningError()
+            submit_task_function.side_effect = error
+            response = self.client.get(url, {})
+            res_json = json.loads(response.content)
+            self.assertIn('status', res_json)
+            self.assertIn('already in progress', res_json['status'])
+
     def test_get_students_features(self):
         """
         Test that some minimum of information is formatted
@@ -2544,16 +2649,24 @@ class TestInstructorAPILevelsDataDump(ModuleStoreTestCase, LoginEnrollmentTestCa
 
     @ddt.data(*REPORTS_DATA)
     @ddt.unpack
+    @valid_problem_location
     def test_calculate_report_csv_success(self, report_type, instructor_api_endpoint, task_api_endpoint, extra_instructor_api_kwargs):
         kwargs = {'course_id': unicode(self.course.id)}
         kwargs.update(extra_instructor_api_kwargs)
         url = reverse(instructor_api_endpoint, kwargs=kwargs)
-
-        CourseFinanceAdminRole(self.course.id).add_users(self.instructor)
-        with patch(task_api_endpoint):
-            response = self.client.get(url, {})
-        success_status = "Your {report_type} report is being generated! You can view the status of the generation task in the 'Pending Instructor Tasks' section.".format(report_type=report_type)
-        self.assertIn(success_status, response.content)
+        success_status = (
+            "Your {report_type} report is being generated! "
+            "You can view the status of the generation task in the 'Pending Instructor Tasks' section."
+        ).format(report_type=report_type)
+        if report_type == 'problem responses':
+            with patch(task_api_endpoint):
+                response = self.client.get(url, {'problem_location': ''})
+            self.assertIn(success_status, response.content)
+        else:
+            CourseFinanceAdminRole(self.course.id).add_users(self.instructor)
+            with patch(task_api_endpoint):
+                response = self.client.get(url, {})
+            self.assertIn(success_status, response.content)
 
     @ddt.data(*EXECUTIVE_SUMMARY_DATA)
     @ddt.unpack

--- a/lms/djangoapps/instructor/tests/test_offline_gradecalc.py
+++ b/lms/djangoapps/instructor/tests/test_offline_gradecalc.py
@@ -1,0 +1,107 @@
+"""
+Tests for offline_gradecalc.py
+"""
+import json
+from mock import patch
+
+from courseware.models import OfflineComputedGrade
+from student.models import CourseEnrollment
+from student.tests.factories import UserFactory
+from xmodule.graders import Score
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+from ..offline_gradecalc import offline_grade_calculation, student_grades
+
+
+def mock_grade(_student, _request, course, **_kwargs):
+    """ Return some fake grade data to mock grades.grade() """
+    return {
+        'grade': u'Pass',
+        'totaled_scores': {
+            u'Homework': [
+                Score(earned=10.0, possible=10.0, graded=True, section=u'Subsection 1', module_id=None),
+            ]
+        },
+        'percent': 0.85,
+        'raw_scores': [
+            Score(
+                earned=5.0, possible=5.0, graded=True, section=u'Numerical Input',
+                module_id=course.id.make_usage_key('problem', 'problem1'),
+            ),
+            Score(
+                earned=5.0, possible=5.0, graded=True, section=u'Multiple Choice',
+                module_id=course.id.make_usage_key('problem', 'problem2'),
+            ),
+        ],
+        'section_breakdown': [
+            {'category': u'Homework', 'percent': 1.0, 'detail': u'Homework 1 - Test - 100% (10/10)', 'label': u'HW 01'},
+            {'category': u'Final Exam', 'prominent': True, 'percent': 0, 'detail': u'Final = 0%', 'label': u'Final'}
+        ],
+        'grade_breakdown': [
+            {'category': u'Homework', 'percent': 0.85, 'detail': u'Homework = 85.00% of a possible 85.00%'},
+            {'category': u'Final Exam', 'percent': 0.0, 'detail': u'Final Exam = 0.00% of a possible 15.00%'}
+        ]
+    }
+
+
+class TestOfflineGradeCalc(ModuleStoreTestCase):
+    """ Test Offline Grade Calculation with some mocked grades """
+    def setUp(self):
+        super(TestOfflineGradeCalc, self).setUp()
+
+        with modulestore().default_store(ModuleStoreEnum.Type.split):  # Test with split b/c old mongo keys are messy
+            self.course = CourseFactory.create()
+        self.user = UserFactory.create()
+        CourseEnrollment.enroll(self.user, self.course.id)
+
+        patcher = patch('courseware.grades.grade', new=mock_grade)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_output(self):
+        offline_grades = OfflineComputedGrade.objects
+        self.assertEqual(offline_grades.filter(user=self.user, course_id=self.course.id).count(), 0)
+        offline_grade_calculation(self.course.id)
+        result = offline_grades.get(user=self.user, course_id=self.course.id)
+        decoded = json.loads(result.gradeset)
+        self.assertEqual(decoded['grade'], "Pass")
+        self.assertEqual(decoded['percent'], 0.85)
+        self.assertEqual(decoded['totaled_scores'], {
+            "Homework": [
+                {"earned": 10.0, "possible": 10.0, "graded": True, "section": "Subsection 1", "module_id": None}
+            ]
+        })
+        self.assertEqual(decoded['raw_scores'], [
+            {
+                "earned": 5.0,
+                "possible": 5.0,
+                "graded": True,
+                "section": "Numerical Input",
+                "module_id": unicode(self.course.id.make_usage_key('problem', 'problem1')),
+            },
+            {
+                "earned": 5.0,
+                "possible": 5.0,
+                "graded": True,
+                "section": "Multiple Choice",
+                "module_id": unicode(self.course.id.make_usage_key('problem', 'problem2')),
+            }
+        ])
+        self.assertEqual(decoded['section_breakdown'], [
+            {"category": "Homework", "percent": 1.0, "detail": "Homework 1 - Test - 100% (10/10)", "label": "HW 01"},
+            {"category": "Final Exam", "label": "Final", "percent": 0, "detail": "Final = 0%", "prominent": True}
+        ])
+        self.assertEqual(decoded['grade_breakdown'], [
+            {"category": "Homework", "percent": 0.85, "detail": "Homework = 85.00% of a possible 85.00%"},
+            {"category": "Final Exam", "percent": 0.0, "detail": "Final Exam = 0.00% of a possible 15.00%"}
+        ])
+
+    def test_student_grades(self):
+        """ Test that the data returned by student_grades() and grades.grade() match """
+        offline_grade_calculation(self.course.id)
+        with patch('courseware.grades.grade', side_effect=AssertionError('Should not re-grade')):
+            result = student_grades(self.user, None, self.course, use_offline=True)
+        self.assertEqual(result, mock_grade(self.user, None, self.course))

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -35,7 +35,7 @@ from util.file import (
     store_uploaded_file, course_and_time_based_filename_generator,
     FileValidationException, UniversalNewlineIterator
 )
-from util.json_request import JsonResponse
+from util.json_request import JsonResponse, JsonResponseBadRequest
 from instructor.views.instructor_task_helpers import extract_email_features, extract_task_features
 
 from microsite_configuration import microsite
@@ -107,7 +107,7 @@ from .tools import (
     bulk_email_is_enabled_for_course,
     add_block_ids,
 )
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from opaque_keys import InvalidKeyError
 from openedx.core.djangoapps.course_groups.cohorts import is_course_cohorted
@@ -885,6 +885,51 @@ def list_course_role_members(request, course_id):
         )),
     }
     return JsonResponse(response_payload)
+
+
+@ensure_csrf_cookie
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@require_level('staff')
+def get_problem_responses(request, course_id):
+    """
+    Initiate generation of a CSV file containing all student answers
+    to a given problem.
+
+    Responds with JSON
+        {"status": "... status message ..."}
+
+    if initiation is successful (or generation task is already running).
+
+    Responds with BadRequest if problem location is faulty.
+    """
+    course_key = CourseKey.from_string(course_id)
+    problem_location = request.GET.get('problem_location', '')
+
+    try:
+        problem_key = UsageKey.from_string(problem_location)
+        # Are we dealing with an "old-style" problem location?
+        run = getattr(problem_key, 'run')
+        if not run:
+            problem_key = course_key.make_usage_key_from_deprecated_string(problem_location)
+        if problem_key.course_key != course_key:
+            raise InvalidKeyError(type(problem_key), problem_key)
+    except InvalidKeyError:
+        return JsonResponseBadRequest(_("Could not find problem with this location."))
+
+    try:
+        instructor_task.api.submit_calculate_problem_responses_csv(request, course_key, problem_location)
+        success_status = _(
+            "Your problem responses report is being generated! "
+            "You can view the status of the generation task in the 'Pending Instructor Tasks' section."
+        )
+        return JsonResponse({"status": success_status})
+    except AlreadyRunningError:
+        already_running_status = _(
+            "A problem responses report generation task is already in progress. "
+            "Check the 'Pending Tasks' table for the status of the task. "
+            "When completed, the report will be available for download in the table below."
+        )
+        return JsonResponse({"status": already_running_status})
 
 
 @ensure_csrf_cookie

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -17,6 +17,8 @@ urlpatterns = patterns(
         'instructor.views.api.modify_access', name="modify_access"),
     url(r'^bulk_beta_modify_access$',
         'instructor.views.api.bulk_beta_modify_access', name="bulk_beta_modify_access"),
+    url(r'^get_problem_responses$',
+        'instructor.views.api.get_problem_responses', name="get_problem_responses"),
     url(r'^get_grading_config$',
         'instructor.views.api.get_grading_config', name="get_grading_config"),
     url(r'^get_students_features(?P<csv>/csv)?$',

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -325,7 +325,7 @@ def _section_course_info(course, access):
         'has_started': course.has_started(),
         'has_ended': course.has_ended(),
         'start_date': get_default_time_display(course.start),
-        'end_date': get_default_time_display(course.end),
+        'end_date': get_default_time_display(course.end) or _('No end date set'),
         'num_sections': len(course.children),
         'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': unicode(course_key)}),
     }

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -459,6 +459,7 @@ def _section_data_download(course, access):
         'section_key': 'data_download',
         'section_display_name': _('Data Download'),
         'access': access,
+        'get_problem_responses_url': reverse('get_problem_responses', kwargs={'course_id': unicode(course_key)}),
         'get_grading_config_url': reverse('get_grading_config', kwargs={'course_id': unicode(course_key)}),
         'get_students_features_url': reverse('get_students_features', kwargs={'course_id': unicode(course_key)}),
         'get_students_who_may_enroll_url': reverse(

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -39,6 +39,7 @@ from course_modes.models import CourseMode, CourseModesArchive
 from student.roles import CourseFinanceAdminRole, CourseSalesAdminRole
 from certificates.models import CertificateGenerationConfiguration
 from certificates import api as certs_api
+from util.date_utils import get_default_time_display
 
 from class_dashboard.dashboard_data import get_section_display_name, get_array_section_has_problem
 from .tools import get_units_with_due_date, title_or_url, bulk_email_is_enabled_for_course
@@ -323,6 +324,9 @@ def _section_course_info(course, access):
         'course_display_name': course.display_name,
         'has_started': course.has_started(),
         'has_ended': course.has_ended(),
+        'start_date': get_default_time_display(course.start),
+        'end_date': get_default_time_display(course.end),
+        'num_sections': len(course.children),
         'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': unicode(course_key)}),
     }
 

--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -276,35 +276,6 @@ def instructor_dashboard(request, course_id):
                     msg += msg2
 
     #----------------------------------------
-    # DataDump
-
-    elif 'Download CSV of all responses to problem' in action:
-        problem_to_dump = request.POST.get('problem_to_dump', '')
-
-        if problem_to_dump[-4:] == ".xml":
-            problem_to_dump = problem_to_dump[:-4]
-        try:
-            module_state_key = course_key.make_usage_key_from_deprecated_string(problem_to_dump)
-            smdat = StudentModule.objects.filter(
-                course_id=course_key,
-                module_state_key=module_state_key
-            )
-            smdat = smdat.order_by('student')
-            msg += _("Found {num} records to dump.").format(num=smdat)
-        except Exception as err:  # pylint: disable=broad-except
-            msg += "<font color='red'>{text}</font><pre>{err}</pre>".format(
-                text=_("Couldn't find module with that urlname."),
-                err=escape(err)
-            )
-            smdat = []
-
-        if smdat:
-            datatable = {'header': ['username', 'state']}
-            datatable['data'] = [[x.student.username, x.state] for x in smdat]
-            datatable['title'] = _('Student state for problem {problem}').format(problem=problem_to_dump)
-            return return_csv('student_state_from_{problem}.csv'.format(problem=problem_to_dump), datatable)
-
-    #----------------------------------------
     # enrollment
 
     elif action == 'Enroll multiple students':

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -11,11 +11,13 @@ from shoppingcart.models import (
 from django.db.models import Q
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
-import xmodule.graders as xmgraders
 from django.core.exceptions import ObjectDoesNotExist
+from django.core.urlresolvers import reverse
+from opaque_keys.edx.keys import UsageKey
+import xmodule.graders as xmgraders
 from microsite_configuration import microsite
 from student.models import CourseEnrollmentAllowed
+from courseware.models import StudentModule
 
 
 STUDENT_FEATURES = ('id', 'username', 'first_name', 'last_name', 'is_staff', 'email')
@@ -294,6 +296,41 @@ def coupon_codes_features(features, coupons_list, course_id):
         coupon_dict['course_id'] = coupon_dict['course_id'].to_deprecated_string()
         return coupon_dict
     return [extract_coupon(coupon, features) for coupon in coupons_list]
+
+
+def list_problem_responses(course_key, problem_location):
+    """
+    Return responses to a given problem as a dict.
+
+    list_problem_responses(course_key, problem_location)
+
+    would return [
+        {'username': u'user1', 'state': u'...'},
+        {'username': u'user2', 'state': u'...'},
+        {'username': u'user3', 'state': u'...'},
+    ]
+
+    where `state` represents a student's response to the problem
+    identified by `problem_location`.
+    """
+    problem_key = UsageKey.from_string(problem_location)
+    # Are we dealing with an "old-style" problem location?
+    run = getattr(problem_key, 'run')
+    if not run:
+        problem_key = course_key.make_usage_key_from_deprecated_string(problem_location)
+    if problem_key.course_key != course_key:
+        return []
+
+    smdat = StudentModule.objects.filter(
+        course_id=course_key,
+        module_state_key=problem_key
+    )
+    smdat = smdat.order_by('student')
+
+    return [
+        {'username': response.student.username, 'state': response.state}
+        for response in smdat
+    ]
 
 
 def course_registration_features(features, registration_codes, csv_type):

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -2,30 +2,31 @@
 Tests for instructor.basic
 """
 
+import datetime
 import json
-from student.models import CourseEnrollment, CourseEnrollmentAllowed
+import pytz
+from mock import MagicMock, Mock, patch
 from django.core.urlresolvers import reverse
-from mock import patch
+from django.db.models import Q
+
+from course_modes.models import CourseMode
+from courseware.tests.factories import InstructorFactory
+from instructor_analytics.basic import (
+    StudentModule, sale_record_features, sale_order_record_features, enrolled_students_features,
+    course_registration_features, coupon_codes_features, list_may_enroll,
+    list_problem_responses, AVAILABLE_FEATURES, STUDENT_FEATURES, PROFILE_FEATURES
+)
+from opaque_keys.edx.locator import UsageKey
+from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
+from student.models import CourseEnrollment, CourseEnrollmentAllowed
 from student.roles import CourseSalesAdminRole
 from student.tests.factories import UserFactory, CourseModeFactory
 from shoppingcart.models import (
     CourseRegistrationCode, RegistrationCodeRedemption, Order,
     Invoice, Coupon, CourseRegCodeItem, CouponRedemption, CourseRegistrationCodeInvoiceItem
 )
-from course_modes.models import CourseMode
-from instructor_analytics.basic import (
-    sale_record_features, sale_order_record_features, enrolled_students_features,
-    course_registration_features, coupon_codes_features, list_may_enroll,
-    AVAILABLE_FEATURES, STUDENT_FEATURES, PROFILE_FEATURES
-)
-from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
-from courseware.tests.factories import InstructorFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
-
-import datetime
-from django.db.models import Q
-import pytz
 
 
 class TestAnalyticsBasic(ModuleStoreTestCase):
@@ -49,6 +50,48 @@ class TestAnalyticsBasic(ModuleStoreTestCase):
             CourseEnrollmentAllowed.objects.create(
                 email=student.email, course_id=self.course_key
             )
+
+    def test_list_problem_responses(self):
+        def result_factory(result_id):
+            """
+            Return a dummy StudentModule object that can be queried for
+            relevant info (student.username and state).
+            """
+            result = Mock(spec=['student', 'state'])
+            result.student.username.return_value = u'user{}'.format(result_id)
+            result.state.return_value = u'state{}'.format(result_id)
+            return result
+
+        # Ensure that UsageKey.from_string returns a problem key that list_problem_responses can work with
+        # (even when called with a dummy location):
+        mock_problem_key = Mock(return_value=u'')
+        mock_problem_key.course_key = self.course_key
+        with patch.object(UsageKey, 'from_string') as patched_from_string:
+            patched_from_string.return_value = mock_problem_key
+
+            # Ensure that StudentModule.objects.filter returns a result set that list_problem_responses can work with
+            # (this keeps us from having to create fixtures for this test):
+            mock_results = MagicMock(return_value=[result_factory(n) for n in range(5)])
+            with patch.object(StudentModule, 'objects') as patched_manager:
+                patched_manager.filter.return_value = mock_results
+
+                mock_problem_location = ''
+                problem_responses = list_problem_responses(self.course_key, problem_location=mock_problem_location)
+
+                # Check if list_problem_responses called UsageKey.from_string to look up problem key:
+                patched_from_string.assert_called_once_with(mock_problem_location)
+                # Check if list_problem_responses called StudentModule.objects.filter to obtain relevant records:
+                patched_manager.filter.assert_called_once_with(
+                    course_id=self.course_key, module_state_key=mock_problem_key
+                )
+
+                # Check if list_problem_responses returned expected results:
+                self.assertEqual(len(problem_responses), len(mock_results))
+                for mock_result in mock_results:
+                    self.assertTrue(
+                        {'username': mock_result.student.username, 'state': mock_result.state} in
+                        problem_responses
+                    )
 
     def test_enrolled_students_features_username(self):
         self.assertIn('username', AVAILABLE_FEATURES)

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -18,6 +18,7 @@ from instructor_task.tasks import (
     reset_problem_attempts,
     delete_problem_state,
     send_bulk_course_email,
+    calculate_problem_responses_csv,
     calculate_grades_csv,
     calculate_problem_grade_report,
     calculate_students_features_csv,
@@ -324,6 +325,21 @@ def submit_bulk_course_email(request, course_key, email_id):
     task_key_stub = "{email_id}_{to_option}".format(email_id=email_id, to_option=to_option)
     # create the key value by using MD5 hash:
     task_key = hashlib.md5(task_key_stub).hexdigest()
+    return submit_task(request, task_type, task_class, course_key, task_input, task_key)
+
+
+def submit_calculate_problem_responses_csv(request, course_key, problem_location):  # pylint: disable=invalid-name
+    """
+    Submits a task to generate a CSV file containing all student
+    answers to a given problem.
+
+    Raises AlreadyRunningError if said file is already being updated.
+    """
+    task_type = 'problem_responses_csv'
+    task_class = calculate_problem_responses_csv
+    task_input = {'problem_location': problem_location}
+    task_key = ""
+
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)
 
 

--- a/lms/djangoapps/instructor_task/tasks.py
+++ b/lms/djangoapps/instructor_task/tasks.py
@@ -34,6 +34,7 @@ from instructor_task.tasks_helper import (
     rescore_problem_module_state,
     reset_attempts_module_state,
     delete_problem_module_state,
+    upload_problem_responses_csv,
     upload_grades_csv,
     upload_problem_grade_report,
     upload_students_csv,
@@ -142,6 +143,18 @@ def send_bulk_course_email(entry_id, _xmodule_instance_args):
     action_name = ugettext_noop('emailed')
     visit_fcn = perform_delegate_email_batches
     return run_main_task(entry_id, visit_fcn, action_name)
+
+
+@task(base=BaseInstructorTask, routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY)  # pylint: disable=not-callable
+def calculate_problem_responses_csv(entry_id, xmodule_instance_args):
+    """
+    Compute student answers to a given problem and upload the CSV to
+    an S3 bucket for download.
+    """
+    # Translators: This is a past-tense verb that is inserted into task progress messages as {action}.
+    action_name = ugettext_noop('generated')
+    task_fn = partial(upload_problem_responses_csv, xmodule_instance_args)
+    return run_main_task(entry_id, task_fn, action_name)
 
 
 @task(base=BaseInstructorTask, routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY)  # pylint: disable=not-callable

--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -4,6 +4,7 @@ running state of a course.
 
 """
 import json
+import re
 from collections import OrderedDict
 from datetime import datetime
 from django.conf import settings
@@ -45,7 +46,11 @@ from courseware.grades import iterate_grades_for
 from courseware.models import StudentModule
 from courseware.model_data import FieldDataCache
 from courseware.module_render import get_module_for_descriptor_internal
-from instructor_analytics.basic import enrolled_students_features, list_may_enroll
+from instructor_analytics.basic import (
+    enrolled_students_features,
+    list_may_enroll,
+    list_problem_responses
+)
 from instructor_analytics.csvs import format_dictlist
 from instructor_task.models import ReportStore, InstructorTask, PROGRESS
 from lms.djangoapps.lms_xblock.runtime import LmsPartitionService
@@ -846,6 +851,40 @@ def _order_problems(blocks):
                 problems[problem] = [header_name + " (Earned)", header_name + " (Possible)"]
 
     return problems
+
+
+def upload_problem_responses_csv(_xmodule_instance_args, _entry_id, course_id, task_input, action_name):
+    """
+    For a given `course_id`, generate a CSV file containing
+    all student answers to a given problem, and store using a `ReportStore`.
+    """
+    start_time = time()
+    start_date = datetime.now(UTC)
+    num_reports = 1
+    task_progress = TaskProgress(action_name, num_reports, start_time)
+    current_step = {'step': 'Calculating students answers to problem'}
+    task_progress.update_task_state(extra_meta=current_step)
+
+    # Compute result table and format it
+    problem_location = task_input.get('problem_location')
+    student_data = list_problem_responses(course_id, problem_location)
+    features = ['username', 'state']
+    header, rows = format_dictlist(student_data, features)
+
+    task_progress.attempted = task_progress.succeeded = len(rows)
+    task_progress.skipped = task_progress.total - task_progress.attempted
+
+    rows.insert(0, header)
+
+    current_step = {'step': 'Uploading CSV'}
+    task_progress.update_task_state(extra_meta=current_step)
+
+    # Perform the upload
+    problem_location = re.sub(r'[:/]', '_', problem_location)
+    csv_name = 'student_state_from_{}'.format(problem_location)
+    upload_csv_to_report_store(rows, csv_name, course_id, start_date)
+
+    return task_progress.update_task_state(extra_meta=current_step)
 
 
 def upload_problem_grade_report(_xmodule_instance_args, _entry_id, course_id, _task_input, action_name):

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -14,6 +14,7 @@ from instructor_task.api import (
     submit_reset_problem_attempts_for_all_students,
     submit_delete_problem_state_for_all_students,
     submit_bulk_course_email,
+    submit_calculate_problem_responses_csv,
     submit_calculate_students_features_csv,
     submit_cohort_students,
     submit_detailed_enrollment_features_csv,
@@ -200,6 +201,14 @@ class InstructorTaskCourseSubmitTest(TestReportMixin, InstructorTaskCourseTestCa
             self.create_task_request(self.instructor),
             self.course.id,
             email_id
+        )
+        self._test_resubmission(api_call)
+
+    def test_submit_calculate_problem_responses(self):
+        api_call = lambda: submit_calculate_problem_responses_csv(
+            self.create_task_request(self.instructor),
+            self.course.id,
+            problem_location=''
         )
         self._test_resubmission(api_call)
 

--- a/lms/static/coffee/src/instructor_dashboard/data_download.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/data_download.coffee
@@ -21,6 +21,8 @@ class DataDownload
     @$list_studs_btn = @$section.find("input[name='list-profiles']'")
     @$list_studs_csv_btn = @$section.find("input[name='list-profiles-csv']'")
     @$list_may_enroll_csv_btn = @$section.find("input[name='list-may-enroll-csv']")
+    @$list_problem_responses_csv_input = @$section.find("input[name='problem-location']")
+    @$list_problem_responses_csv_btn = @$section.find("input[name='list-problem-responses-csv']")
     @$list_anon_btn = @$section.find("input[name='list-anon-ids']'")
     @$grade_config_btn = @$section.find("input[name='dump-gradeconf']'")
     @$calculate_grades_csv_btn = @$section.find("input[name='calculate-grades-csv']'")
@@ -96,6 +98,22 @@ class DataDownload
           @$download_display_table.append $table_placeholder
           grid = new Slick.Grid($table_placeholder, grid_data, columns, options)
           # grid.autosizeColumns()
+
+    @$list_problem_responses_csv_btn.click (e) =>
+      @clear_display()
+
+      url = @$list_problem_responses_csv_btn.data 'endpoint'
+      $.ajax
+        dataType: 'json'
+        url: url
+        data:
+          problem_location: @$list_problem_responses_csv_input.val()
+        error: (std_ajax_err) =>
+          @$reports_request_response_error.text JSON.parse(std_ajax_err['responseText'])
+          $(".msg-error").css({"display":"block"})
+        success: (data) =>
+          @$reports_request_response.text data['status']
+          $(".msg-confirm").css({"display":"block"})
 
     @$list_may_enroll_csv_btn.click (e) =>
       @clear_display()

--- a/lms/templates/courseware/legacy_instructor_dashboard.html
+++ b/lms/templates/courseware/legacy_instructor_dashboard.html
@@ -364,9 +364,8 @@ function goto( mode)
 
 %if modeflag.get('Data'):
     <hr width="40%" style="align:left">
-    <p> ${_("Problem urlname:")}
-        <input type="text" name="problem_to_dump" size="40">
-        <input type="submit" name="action" value="Download CSV of all responses to problem">
+    <p class="is-deprecated">
+      ${_("To download a CSV listing student responses to a given problem, visit the Data Download section of the Instructor Dashboard.")}
     </p>
 
     <p class="is-deprecated">

--- a/lms/templates/instructor/instructor_dashboard_2/course_info.html
+++ b/lms/templates/instructor/instructor_dashboard_2/course_info.html
@@ -73,6 +73,22 @@
       <b>${_("No")}</b>
       %endif
     </li>
+
+    <li class="field text is-not-editable" id="field-course-start-date">
+      <label for="course-start-date">${_("Course Start Date:")}</label>
+      <b>${ section_data['start_date'] }</b>
+    </li>
+
+    <li class="field text is-not-editable" id="field-course-end-date">
+      <label for="course-end-date">${_("Course End Date:")}</label>
+      <b>${ section_data['end_date'] }</b>
+    </li>
+
+    <li class="field text is-not-editable" id="field-course-num-sections">
+      <label for="course-num-sections">${_("Number of sections (weeks):")}</label>
+      <b>${ section_data['num_sections'] }</b>
+    </li>
+
     <li class="field text is-not-editable" id="field-grade-cutoffs">
       <label for="start-date">${_("Grade Cutoffs:")}</label>
       <b>${ section_data['grade_cutoffs'] }</b>

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -35,6 +35,18 @@
 
     <p><input type="button" name="list-may-enroll-csv" value="${_("Download a CSV of learners who can enroll")}" data-endpoint="${ section_data['get_students_who_may_enroll_url'] }" data-csv="true"></p>
 
+    <p>${_("To generate a CSV file that lists all student answers to a given problem, enter the location of the problem (from its Staff Debug Info).")}</p>
+
+    <p>
+      <label>
+        <span>${_("Problem location: ")}</span>
+        <input type="text" name="problem-location" />
+      </label>
+    </p>
+    <p>
+      <input type="button" name="list-problem-responses-csv" value="${_("Download a CSV of problem responses")}" data-endpoint="${ section_data['get_problem_responses_url'] }" data-csv="true">
+    </p>
+
   % if not disable_buttons:
     <p>${_("For smaller courses, click to list profile information for enrolled students directly on this page:")}</p>
     <p><input type="button" name="list-profiles" value="${_("List enrolled students' profile information")}" data-endpoint="${ section_data['get_students_features_url'] }"></p>
@@ -50,7 +62,7 @@
   %endif
 
     <div class="request-response msg msg-confirm copy" id="report-request-response"></div>
-    <div class="request-response-error msg msg-warning copy" id="report-request-response-error"></div>
+    <div class="request-response-error msg msg-error copy" id="report-request-response-error"></div>
     <br>
 
     <p><b>${_("Reports Available for Download")}</b></p>


### PR DESCRIPTION
This PR is a backport of four LMS feature PRs that are already merged to upstream master, and two that haven't been merged upstream yet.
- https://github.com/edx/edx-platform/pull/9146 Instructor Dashboard: Display info about course timeline
- https://github.com/edx/edx-platform/pull/9147 Move problem responses export from legacy instructor dash to new instructor dash
- https://github.com/edx/edx-platform/pull/9483 Instructor dashboard: Improve course timeline info
- https://github.com/edx/edx-platform/pull/9330 Fix Offline Grade Calculation
- https://github.com/edx/edx-platform/pull/9345 List a student's courses via the Enrollment API
- https://github.com/edx/edx-platform/pull/9616 Emit events when users vote on forum posts

The first three PRs were rebased by @itsjeyd in #1.

If the Rue89 fork/instance is updated to 2438b27b9cdee2340a89a162daf77832f7e671ce or newer then these commits do not need to be preserved/rebased as they will already be included. (EDIT: except 9345 and 9616, which are not merged upstream yet)

**Sandbox**: http://rue89-analytics.sandbox.opencraft.com/ (Updated to f61384f)

Test status on sandbox with f61384f:
- python cms: `964 skipped (1857 tests passed)`
- python lms: some test failures
- python common/lib/calc: `(55 tests passed)`
- python common/lib/(various): all passed
