### PR TITLE
Fix issue with certificates and badges

### DIFF
--- a/lms/djangoapps/badges/models.py
+++ b/lms/djangoapps/badges/models.py
@@ -6,6 +6,7 @@ from importlib import import_module
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
+from django.core.files.base import ContentFile
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from jsonfield import JSONField
@@ -97,7 +98,7 @@ class BadgeClass(models.Model):
             description=description,
             criteria=criteria,
         )
-        badge_class.image.save(image_file_handle.name, image_file_handle)
+        badge_class.image.save(image_file_handle.name, ContentFile(image_file_handle.read()))
         badge_class.full_clean()
         badge_class.save()
         return badge_class

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -445,9 +445,11 @@ def _update_badge_context(context, course, user):
     """
     badge = None
     if badges_enabled() and course.issue_badges:
-        badges = get_completion_badge(course.location.course_key, user).get_for_user(user)
-        if badges:
-            badge = badges[0]
+        badge_class = get_completion_badge(course.location.course_key, user)
+        if badge_class:
+            badges = badge_class.get_for_user(user)
+            if badges:
+                badge = badges[0]
     context['badge'] = badge
 
 


### PR DESCRIPTION
This may be just a staging data issue, but it's blocking us from testing certificates, so this patch fixes the code that's erroring out.

**Testing instructions**:

`edxstage-15c` (`52.212.10.206`) is running `rue89-release`, and is currently linked to `stage.mooc.rue89.com`.  To verify the existing issue:
1. Login here: http://studio.stage.mooc.rue89.com/certificates/course-v1:RUE89+TESt+TEST
1. Click Preview Certificate - error message

`edxstage-16b (`52.210.249.131`) is running `jill/fix-badges-certificates`.  To verify the patch:
1. Map `**52.213.33.101** studio.stage.mooc.rue89.com` in your `/etc/hosts`.
1. Login here: http://studio.stage.mooc.rue89.com/certificates/course-v1:RUE89+TESt+TEST
1. Click Preview Certificate - working cert.

*Reviewer*
- [ ] @mtyaka