### PR TITLE
Adds update_anonymous_user_ids management command

### DIFF
--- a/common/djangoapps/student/management/commands/update_anonymous_user_ids.py
+++ b/common/djangoapps/student/management/commands/update_anonymous_user_ids.py
@@ -1,0 +1,108 @@
+import logging
+
+from django.core.management.base import BaseCommand
+from django.db import IntegrityError
+from student.models import AnonymousUserId, anonymous_id_for_user
+from submissions.models import StudentItem, ScoreAnnotation
+from openassessment.assessment.models import (
+    AIGradingWorkflow, Assessment, PeerWorkflow, StaffWorkflow, StudentTrainingWorkflow,
+)
+
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+
+class Command(BaseCommand):
+    help = """
+    We can now have multiple anonymous user ids for a given user+course.
+    This is useful if we have to change the app's SECRET_KEY, which is used to generate the anonymous user ids.
+    Ref: https://github.com/edx/edx-platform/pull/13717
+
+    However, some models don't reference the Student.AnonymousUserId model directly,
+    and keep their own copies of the anonymous user ID.
+
+    This command runs through an explicit list of those models and fields, and updates
+    them to use the most recently-generated anonymous user ID.
+    """
+
+    def handle(self, *args, **options):
+        """Update the anonymous IDs used by the given models and fields."""
+
+        self.generate_anonymous_user_ids()
+        anon_ids_map = self.get_old_to_new_anonymous_user_ids()
+
+        # Update each of the old anonymous IDs with the new one.
+        for (model, field_name) in (
+            (StudentItem, 'student_id'),
+            (ScoreAnnotation, 'creator'),
+            (AIGradingWorkflow, 'student_id'),
+            (Assessment, 'scorer_id'),
+            (PeerWorkflow, 'student_id'),
+            (StaffWorkflow, 'scorer_id'),
+            (StudentTrainingWorkflow, 'student_id'),
+        ):
+            self.update_anonymous_user_ids(model, field_name, anon_ids_map)
+
+    @staticmethod
+    def generate_anonymous_user_ids():
+        '''Generate new anonymous user id using the current settings.SECRET_KEY.'''
+        for anonymous_id in AnonymousUserId.objects.all():
+            anonymous_id_for_user(anonymous_id.user, anonymous_id.course_id, save=True)
+
+    @staticmethod
+    def get_old_to_new_anonymous_user_ids():
+        '''Returns a mapping between each existing anonymous user id and the most recent one found in the database.'''
+        user_course_id = {}
+        old_to_new_anon_id = {}
+
+        # Sort by descending id, to see the newest rows first.
+        for anonymous_id in AnonymousUserId.objects.order_by('-id').all():
+
+            # If we haven't seen this user+course combination yet, then this is the newest anonymous id.
+            if not (anonymous_id.user_id, anonymous_id.course_id) in user_course_id:
+                user_course_id[anonymous_id.user_id, anonymous_id.course_id] = anonymous_id.anonymous_user_id
+
+            # If we have seen it, then newest anonymous id has already been set.
+            new_anonymous_user_id = user_course_id[anonymous_id.user_id, anonymous_id.course_id]
+            old_to_new_anon_id[anonymous_id.anonymous_user_id] = new_anonymous_user_id
+
+        return old_to_new_anon_id
+
+    @staticmethod
+    def update_anonymous_user_ids(model, field_name, old_to_new_anon_id):
+        '''Updates the given model.field values to use the new anonymous user id, if found.'''
+        total = 0
+        unchanged = 0
+        updated = 0
+        errors = 0
+        try:
+            for item in model.objects.all():
+                total += 1
+                old_anon_id = getattr(item, field_name)
+                new_anon_id = old_to_new_anon_id.get(old_anon_id)
+                if new_anon_id is not None:
+                    if old_anon_id != new_anon_id:
+                        try:
+                            setattr(item, field_name, old_to_new_anon_id[old_anon_id])
+                            item.save()
+                            updated += 1
+                        except (IntegrityError, ValueError) as error:
+                            log.error('%s.%s cannot save: %s', model, field_name, error)
+                            errors += 1
+                    else:
+                        unchanged += 1
+                elif old_anon_id is None or old_anon_id == '':
+                    # Skip record: the field value is NULL
+                    unchanged += 1
+                else:
+                    log.error('%s.%s (id=%s) not found in anonymous user ids list?', model, field_name, item.id)
+                    errors += 1
+
+        except AttributeError as error:
+            log.error('%s.%s field not found: %s', model, field_name, error)
+            errors += 1
+
+        log.info('%s.%s: updated %s of %s; %s unchanged; %s errors',
+                 model, field_name, updated, total, unchanged, errors)
+


### PR DESCRIPTION
Adds a management command to update the anonymous user IDs used in submissions and ORA models which will be affected when we change the edxapp `SECRET_KEY`.

**Sandbox URL**

* LMS: http://oc1694.sandbox.opencraft.hosting/
* Studio: http://studio-oc1694.sandbox.opencraft.hosting/

**Testing instructions**

You're welcome to test it in your own way, but here's what I did:

Using [AppServer 3](https://console.opencraft.com/instance/1990/edx-appserver/646/) ([`opencraft-release/eucalyptus.2`](https://github.com/open-craft/edx-platform/tree/opencraft-release/eucalyptus.2)):
1. Exported Rue89's [Ecrire pour le web 2016_T4](https://mooc.rue89.com/courses/course-v1:Rue89+ecrire-pour-le-web+2016_T4/courseware/6ecb09827c8640a2b44d6ab939482f78/46a818fe0ea649b58556d81e8ac78178/) course.
1. Extracted the course tar, and modified the ORA problem to reduce the "Must Grade" from 5 to 2, and "Graded By" from 3 to 1, to make testing easier.  Also adjusted due dates, and course end/enrolment dates.
1. As honor, audit, and staff and completed and graded the ORA problems.  Noted grades.
1. As verified user, submitted a draft answer, but don't complete the ORA yet.

Using [AppServer 4](https://console.opencraft.com/instance/1990/edx-appserver/647/) ([`eucalyptus.2 + Sven's anonymous_id change`](https://github.com/open-craft/edx-platform/tree/jill/eucalyptus.2-anonymous_id_fix)):
1. Changed the edxapp `SECRET_KEY`.
1. Login as each student.  Noted that my ORA submissions and grades were missing.
1. Installed this PR's `update_anonymous_user_ids.py` to `common/djangoapps/student/management/commands`, and ran:

  ```
edxapp@oc1694:~/edx-platform$ ./manage.py lms --settings=openstack update_anonymous_user_ids
2016-11-23 05:31:02,924 INFO 20513 [student.management.commands.update_anonymous_user_ids] update_anonymous_user_ids.py:102 - <class 'submissions.models.StudentItem'>.student_id: updated 3 of 3; 0 unchanged; 0 errors
2016-11-23 05:31:02,929 INFO 20513 [student.management.commands.update_anonymous_user_ids] update_anonymous_user_ids.py:102 - <class 'submissions.models.ScoreAnnotation'>.creator: updated 0 of 0; 0 unchanged; 0 errors
2016-11-23 05:31:02,934 INFO 20513 [student.management.commands.update_anonymous_user_ids] update_anonymous_user_ids.py:102 - <class 'openassessment.assessment.models.ai.AIGradingWorkflow'>.student_id: updated 0 of 0; 0 unchanged; 0 errors
2016-11-23 05:31:03,011 INFO 20513 [student.management.commands.update_anonymous_user_ids] update_anonymous_user_ids.py:102 - <class 'openassessment.assessment.models.base.Assessment'>.scorer_id: updated 5 of 5; 0 unchanged; 0 errors
2016-11-23 05:31:03,072 INFO 20513 [student.management.commands.update_anonymous_user_ids] update_anonymous_user_ids.py:102 - <class 'openassessment.assessment.models.peer.PeerWorkflow'>.student_id: updated 3 of 3; 0 unchanged; 0 errors
2016-11-23 05:39:33,709 INFO 22504 [student.management.commands.update_anonymous_user_ids] update_anonymous_user_ids.py:105 - <class 'openassessment.assessment.models.staff.StaffWorkflow'>.scorer_id: updated 0 of 3; 3 unchanged; 0 errors
2016-11-23 05:31:03,086 INFO 20513 [student.management.commands.update_anonymous_user_ids] update_anonymous_user_ids.py:102 - <class 'openassessment.assessment.models.student_training.StudentTrainingWorkflow'>.student_id: updated 0 of 0; 0 unchanged; 0 errors
  ```
1. Login as each student.  Ensure I can see my submission and grades, and nothing has changed.
1. Finish ORA problem left by final student, and grade that submission.  Ensure grading process works.

**Reviewer**
- [ ] @haikuginger 